### PR TITLE
feat: Added Brazilian Portuguese translations

### DIFF
--- a/app/src/main/res/values/values-pt-BR/strings.xml
+++ b/app/src/main/res/values/values-pt-BR/strings.xml
@@ -1,0 +1,45 @@
+<resources>
+    <string name="app_name" translatable="false">ReVanced Manager</string>
+    <string name="app_selector_title">Selecionar um aplicativo…</string>
+
+    <string name="app_bar_open_discord">Discord</string>
+    <string name="app_bar_open_github">GitHub</string>
+
+    <string name="card_announcement_header">Comunicado</string>
+    <string name="card_commits_header">Últimas atualizações</string>
+    <string name="card_logs_header">Registros</string>
+    <string name="card_application_header">Selecionar Aplicativo</string>
+    <string name="card_patches_header">Selecionar Patches</string>
+    <string name="card_options_header">Opções</string>
+    <string name="card_credits_header">Créditos</string>
+
+    <string name="card_commits_body_patcher">Patcher:</string>
+    <string name="card_commits_body_manager">Gerenciador:</string>
+    <string name="card_announcement_body_placeholder">Este é um texto de exemplo para pré-visualização do design do ReVanced Manager que será substituído por anúncios dinâmicos no futuro.</string>
+    <string name="card_options_body_root">Root</string>
+    <string name="card_options_body_use_installed">Usar o aplicativo do YouTube instalado</string>
+    <string name="card_application_body">Nenhum aplicativo selecionado.</string>
+    <string name="card_patches_body_source">Nenhuma fonte de patch selecionada.</string>
+    <string name="card_patches_body_patches">Nenhum patch selecionado.</string>
+    <string name="card_application_body_selected">Selecionado:</string>
+    <string name="card_logs_body">Clique aqui para ver os registros do patcher.</string>
+    <string name="card_credits_body">Clique aqui para ver os créditos do projeto ReVanced.</string>
+
+    <string name="loading_body">Por favor, aguarde...</string>
+    <string name="loading_fetching_patches">Obtendo patches</string>
+
+    <string name="card_announcement_button_changelog">Registro de alterações</string>
+
+    <string name="button_patch">Patch</string>
+
+    <string name="navigation_dashboard">Painel de navegação</string>
+    <string name="navigation_patcher">Patcher</string>
+
+    <string name="screen_logs_title">Relatórios</string>
+    <string name="screen_credits_title">Créditos</string>
+    <string name="screen_credits_team_manager">ReVanced Manager</string>
+    <string name="screen_credits_team_website">Website</string>
+    <string name="screen_credits_team">Equipe</string>
+    <string name="screen_credits_translators">Tradutores</string>
+    <string name="screen_credits_team_patcher">Patcher</string>
+</resources>


### PR DESCRIPTION
Some considerations:

1. Strings available on the file sourced from Crowdin and shared as a zip on Discord are unchanged;

2. New strings are translated in a friendly way, following the spirit of the original translations from Crowdin;

3. The "ReVanced Manager" name was kept as is (following the dev team guidelines);

4. File structure is unchanged, although I've added an empty line at the end of the file as per good practices :kissing_smiling_eyes: